### PR TITLE
[Add][28기 한상일]공용으로 사용하는 nav 컴포넌트 레이아웃 완료

### DIFF
--- a/src/ pages/Login/Login.js
+++ b/src/ pages/Login/Login.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import './Login.scss';
 
 function Login() {

--- a/src/ pages/Login/Login.js
+++ b/src/ pages/Login/Login.js
@@ -1,9 +1,14 @@
 import React from 'react';
-
+import Nav from '../../components/Nav';
 import './Login.scss';
 
 function Login() {
-  return <div>login</div>;
+  // return <div>login</div>;
+  return (
+    <div>
+      <Nav />
+    </div>
+  );
 }
 
 export default Login;

--- a/src/components/CSCENTERLIST.js
+++ b/src/components/CSCENTERLIST.js
@@ -1,0 +1,5 @@
+export const CSCENTERLIST = [
+  { id: 1, content: '공지사항' },
+  { id: 2, content: '자주하는 질문' },
+  { id: 3, content: '1:1 문의' },
+];

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -1,8 +1,98 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import NavLogo from './Navlogo';
+import { CSCENTERLIST } from './CSCENTERLIST';
 import './Nav.scss';
 
-function Nav() {
-  return <div>nav</div>;
-}
+const Nav = () => {
+  const [listOpen, setlistOpen] = useState(false);
+  const listToggleMenu = () => {
+    setlistOpen(listOpen => !listOpen);
+  };
+  const [purpleSmallUis, setpurpleSmallUis] = useState(true);
+  useEffect(() => {
+    setTimeout(() => {
+      setpurpleSmallUis(false);
+    }, 20000);
+  }, []);
+  return (
+    <div className="navLocation">
+      <NavLogo />
+      <a href="https://www.google.co.kr">
+        <p className="leftInfo">
+          <span className="Info"> 샛별·택배</span> 배송안내
+        </p>
+      </a>
+      <li className="rightMenu">
+        <Link to="/signup">
+          <li className="rightMenuli">회원가입</li>
+        </Link>
+        <Link to="/">
+          <li className="rightMenuli">로그인</li>
+        </Link>
+
+        <li className="rightMenuli" onClick={() => listToggleMenu()}>
+          고객센터
+          <ul className={listOpen ? 'show-menu' : 'hide-menu'}>
+            {CSCENTERLIST.map(CSList => {
+              return (
+                <li className="cscenterList" key={CSList.key}>
+                  {CSList.content}
+                </li>
+              );
+            })}
+          </ul>
+        </li>
+      </li>
+
+      <div className="categoriesGroup">
+        <img
+          src="https://img.icons8.com/material-outlined/24/000000/menu--v1.png"
+          className="imgCate"
+          alt="categorieBtn"
+        />
+        <span className="categorieAll">전체 카테고리</span>
+        <span className="categorieMenuV">채소</span>
+        <span className="categorieMenuF">과일</span>
+        <span className="categorieMenuM">정육</span>
+        <span className="categorieMenuFi">수산</span>
+        <input
+          type="text"
+          placeholder="검색어를 입력해주세요"
+          className="searchField"
+        />
+        <button className="imgSearch">
+          <img
+            src="https://img.icons8.com/material-outlined/24/000000/search--v1.png"
+            className="imgSearch"
+            alt="searchBtn"
+          />
+        </button>
+        <img
+          src="https://img.icons8.com/ios/50/000000/marker--v1.png"
+          className="imgLocation"
+          alt="btnLocation"
+        />
+        <img
+          src="https://img.icons8.com/ios-glyphs/30/000000/like--v2.png"
+          className="imgHeart"
+          alt="btnHeart"
+        />
+        <button className="imgCarts">
+          <img
+            src="https://img.icons8.com/ios/50/000000/shopping-cart.png"
+            className="imgCart"
+            alt="btnCart"
+          />
+        </button>
+        {purpleSmallUis === true ? (
+          <div className="purpleSmallUi">
+            <p>지금 가입하고 인기상품을 100원에 받아가세요</p>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+};
 
 export default Nav;

--- a/src/components/Nav.scss
+++ b/src/components/Nav.scss
@@ -1,0 +1,113 @@
+@import '../styles/variables.scss';
+.navLocation {
+  border-bottom: 1px solid $light-grey-border;
+
+  .leftInfo {
+    border: 1px solid $light-grey-border;
+    border-radius: 21px;
+    margin-top: -85px;
+    width: 140px;
+    text-align: center;
+    font-size: 14px;
+    .Info {
+      color: $main-purple;
+    }
+  }
+  .rightMenu {
+    float: right;
+    margin-top: -21px;
+    margin-right: 70px;
+    font-weight: bold;
+    list-style-type: none;
+    text-align: right;
+
+    .rightMenuli {
+      list-style-type: none;
+      text-align: right;
+      float: right;
+      font-size: 13px;
+      padding: 0px 17px 10px;
+    }
+  }
+  .show-menu {
+    width: 100px;
+    height: 30px;
+    margin: 4px 10px 30px 10px;
+    transition: 4s;
+  }
+  .hide-menu {
+    width: 100px;
+    height: 30px;
+    transition: 1s;
+    opacity: 0;
+  }
+  ul {
+    .cscenterList {
+      font-size: 12px;
+      margin: 0px -10px 5px;
+      padding: 3px 1px 3px;
+    }
+  }
+  a {
+    color: $black;
+  }
+  .categoriesGroup {
+    text-align: center;
+    margin-top: 80px;
+    font-weight: 400;
+    font-size: 21px;
+  }
+  #categorieAll {
+    margin-left: 20px;
+  }
+  .categorieMenuV {
+    margin-left: 55px;
+  }
+  .categorieMenuF {
+    margin-left: 60px;
+  }
+  .categorieMenuM {
+    margin-left: 65px;
+  }
+  .categorieMenuFi {
+    margin-left: 70px;
+  }
+  .imgCate {
+    margin-left: 40px;
+  }
+  .imgSearch {
+    position: absolute;
+    transform: translate(-130%, 40%);
+  }
+  .imgLocation {
+    position: absolute;
+    transform: translate(110%, 30%);
+    width: 30px;
+    height: 28px;
+  }
+  .imgHeart {
+    transform: translate(290%, 25%);
+  }
+  .imgCart {
+    transform: translate(340%, 19%);
+    width: 30px;
+  }
+  .searchField {
+    width: 240px;
+    height: 31px;
+    background-color: $light-grey;
+    border-radius: 95px;
+    margin-left: 70px;
+    transform: translate(0, -15%);
+    &::placeholder {
+      text-align: center;
+    }
+  }
+  .purpleSmallUi {
+    text-align: center;
+    line-height: 39px;
+    color: #fff;
+    background-color: $main-purple;
+    height: 43px;
+  }
+}

--- a/src/components/Nav.scss
+++ b/src/components/Nav.scss
@@ -29,23 +29,24 @@
       padding: 0px 17px 10px;
     }
   }
-  .show-menu {
-    width: 100px;
-    height: 30px;
-    margin: 4px 10px 30px 10px;
-    transition: 4s;
-  }
-  .hide-menu {
-    width: 100px;
-    height: 30px;
-    transition: 1s;
-    opacity: 0;
-  }
-  ul {
+
+  .rightMenuli {
     .cscenterList {
       font-size: 12px;
       margin: 0px -10px 5px;
       padding: 3px 1px 3px;
+    }
+    .show-menu {
+      width: 100px;
+      height: 30px;
+      margin: 4px 10px 30px 10px;
+      transition: 4s;
+    }
+    .hide-menu {
+      width: 100px;
+      height: 30px;
+      transition: 1s;
+      opacity: 0;
     }
   }
   a {

--- a/src/components/Navlogo.js
+++ b/src/components/Navlogo.js
@@ -1,0 +1,23 @@
+import React, { useState, useEffect } from 'react';
+import './Navlogo.scss';
+const NavLogo = () => {
+  const logoText = 'Kurly\nFlower';
+  const [text, settext] = useState('');
+  const [count, setcount] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      settext(text + logoText[count]); //이전에 set으로 받아온것 + 다음에 받아올것
+      setcount(count + 1); // 글자가 1글자씩 나오게 함.
+    }, 200); // x초의 간격으로 setInterval 내부의 코드를 1글자씩 출력함.
+    if (count === logoText.length) {
+      // count와 txt.length가 일치할경우 interval 해제
+      clearInterval(interval);
+    }
+    return () => clearInterval(interval); // 언마운트로 interval 해제
+  });
+
+  return <p className="logoText">{text}</p>;
+};
+
+export default NavLogo;

--- a/src/components/Navlogo.scss
+++ b/src/components/Navlogo.scss
@@ -1,0 +1,9 @@
+@import '../styles/variables.scss';
+.logoText {
+  white-space: pre-wrap;
+  font-weight: bold;
+  text-align: center;
+  color: $main-purple;
+  font-size: 31px;
+  padding-top: 20px;
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 기존에 레이아웃 제작한 nav 컴포넌트를 별도의 브랜치로 독립시켜 놨습니다.


<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
-git clone로 기존 진행하는것과 별개의 폴더였으며.
-기존 진행하던 login+signup 브랜치에서 nav 관련파일만 초기 세팅 파일에 추가하였습니다.
-npm run start로 출력되는것만 추가로 확인하였습니다.
-확인후 특이사항이 없다면 다른팀원이 사용할수있도록 머지 부탁드립니다

-2022-01-01 없어도 지장없는 css 코드 제거
<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
-nav 와 footer같은 공용 컴포넌트는 초기세팅 진행시 별개의 브랜치로 분리하여 준비시켜야 한다는걸 알게되었습니다.

<br />

## :: 기타 질문 및 특이 사항
- 함수 로직이 너무 긴 것 같습니다. 좀 더 효율적인 방법이 없을지 궁금합니다.(예시) 
